### PR TITLE
Preserve shopify params on redirect to authentication

### DIFF
--- a/lib/shopifex/plug/shopify_session.ex
+++ b/lib/shopifex/plug/shopify_session.ex
@@ -14,13 +14,13 @@ defmodule Shopifex.Plug.ShopifySession do
     shop_schema = Application.fetch_env!(:shopifex, :shop_schema)
 
     case Phoenix.Controller.get_flash(conn, :shop) do
-      %{__struct__: ^shop_schema} = shop ->
+      %{__struct__: ^shop_schema} = _shop ->
         conn
         |> put_shop_in_session()
 
       _ ->
         conn
-        |> Phoenix.Controller.redirect(to: "/auth")
+        |> Phoenix.Controller.redirect(to: "/auth?#{conn.query_string}")
         |> halt()
     end
   end

--- a/test/plug/shopify_session_test.exs
+++ b/test/plug/shopify_session_test.exs
@@ -1,0 +1,16 @@
+defmodule Shopifex.Plug.ShopifySessionTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  test "redirect location preserves parameters" do
+    Application.put_env(:shopifex, :shop_schema, %{})
+    result = conn(:get, "/?shop=store", %{})
+    |> Map.put(:private, %{phoenix_flash: %{shop: ""}})
+    |> Shopifex.Plug.ShopifySession.call(%{})
+
+    assert result.halted
+    assert result.status == 302
+    assert Plug.Conn.get_resp_header(result, "location") == ["/auth?shop=store"]
+  end
+
+end


### PR DESCRIPTION
Without preserving the `shop` param we will be kicked back to the install page.

Thank you for the library :)