### PR TITLE
Add the ability to modify app permissions after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,21 @@ defmodule MyAppWeb.WebhookController do
   end
 end
 ```
+## Update app permissions
+
+You can also update the app permissions after installation. To do so, first you have to add `your-redirect-url.com/auth/update` to Shopify's whitelist.
+
+Then add the following route to your `/auth` scope:
+
+```
+scope "/auth", MyAppWeb do
+  ...
+  get "/update", AuthController, :update
+end
+```
+
+To add e.g. the `read_customers` scope, you can do so by redirecting them to the following example url:
+
+```
+https://{shop-name}.myshopify.com/admin/oauth/request_grant?client_id=API_KEY&redirect_uri={YOUR_REDIRECT_URL}/auth/update&scope={YOUR_SCOPES},read_customers
+```

--- a/lib/shopifex/shops.ex
+++ b/lib/shopifex/shops.ex
@@ -22,6 +22,11 @@ defmodule Shopifex.Shops do
     |> repo().insert!()
   end
 
+  def update_shop(params, shop) do
+    shop_schema().changeset(shop, params)
+    |> repo().update!()
+  end
+
   def delete_shop(shop) do
     repo().delete!(shop)
   end


### PR DESCRIPTION
Hello Eric!

I am building an app where the user will be able to select a number of different actions on his `shop` which may require different app permissions. So to avoid requesting a bunch of permissions on initial installation, the `shop` can add or remove accordingly.