### PR TITLE
allow shop lookup query to be configurable

### DIFF
--- a/lib/shopifex/guardian.ex
+++ b/lib/shopifex/guardian.ex
@@ -5,7 +5,7 @@ defmodule Shopifex.Guardian do
     secret_key: Application.get_env(:shopifex, :secret),
     allowed_algos: ["HS512", "HS256"]
 
-  def subject_for_token(%{url: url}, _claims), do: {:ok, url}
+  def subject_for_token(shop, _claims), do: {:ok, Shopifex.Shops.get_url(shop)}
 
   @doc """
   Since app bridge tokens are only short lived, we generate

--- a/lib/shopifex/plug/ensure_scopes.ex
+++ b/lib/shopifex/plug/ensure_scopes.ex
@@ -38,11 +38,11 @@ defmodule Shopifex.Plug.EnsureScopes do
 
           missing_scopes ->
             Logger.info(
-              "Shop #{shop.url} is missing required scopes #{inspect(missing_scopes)}, initiating app update"
+              "Shop #{Shopifex.Shops.get_url(shop)} is missing required scopes #{inspect(missing_scopes)}, initiating app update"
             )
 
             reinstall_url =
-              "https://#{shop.url}/admin/oauth/authorize?client_id=#{Application.fetch_env!(:shopifex, :api_key)}&scope=#{Application.fetch_env!(:shopifex, :scopes)}&redirect_uri=#{Application.fetch_env!(:shopifex, :reinstall_uri)}"
+              "https://#{Shopifex.Shops.get_url(shop)}/admin/oauth/authorize?client_id=#{Application.fetch_env!(:shopifex, :api_key)}&scope=#{Application.fetch_env!(:shopifex, :scopes)}&redirect_uri=#{Application.fetch_env!(:shopifex, :reinstall_uri)}"
 
             conn
             |> put_view(ShopifexWeb.PageView)

--- a/lib/shopifex/shop.ex
+++ b/lib/shopifex/shop.ex
@@ -1,0 +1,23 @@
+defmodule Shopifex.Shop do
+  @moduledoc """
+  A specification for how Shopifex is to interact with your Shopify
+  shops table.
+
+  ## Options:
+      * url_field: the field which Shopifex will use to find a shop by url. Defaults to `:url`
+      * filters: a list of tuples to be used as filter keys which Shopifex will use when
+      loading your shop from your database table. Defaults to `[]`.
+  """
+  @default_url_field :url
+  @default_filter_keys []
+
+  defmacro __using__(opts \\ []) do
+    url_key = Keyword.get(opts, :url_field, @default_url_field)
+    filters = Keyword.get(opts, :filters, @default_filter_keys)
+
+    quote do
+      def shopifex_url_field(), do: unquote(url_key)
+      def shopifex_filters(), do: unquote(filters)
+    end
+  end
+end

--- a/lib/shopifex_web/controllers/auth_controller.ex
+++ b/lib/shopifex_web/controllers/auth_controller.ex
@@ -112,7 +112,7 @@ defmodule ShopifexWeb.AuthController do
       def after_install(conn, shop) do
         redirect(conn,
           external:
-            "https://#{shop.url}/admin/apps/#{Application.fetch_env!(:shopifex, :api_key)}"
+            "https://#{Shopifex.Shops.get_url(shop)}/admin/apps/#{Application.fetch_env!(:shopifex, :api_key)}"
         )
       end
 

--- a/lib/shopifex_web/controllers/payment_controller.ex
+++ b/lib/shopifex_web/controllers/payment_controller.ex
@@ -112,9 +112,10 @@ defmodule ShopifexWeb.PaymentController do
                  name: plan.name,
                  price: plan.price,
                  test: plan.test,
-                 return_url: "#{redirect_uri}?plan_id=#{plan.id}&shop=#{shop.url}"
+                 return_url:
+                   "#{redirect_uri}?plan_id=#{plan.id}&shop=#{Shopifex.Shops.get_url(shop)}"
                },
-               url: "https://#{shop.url}/admin/api/2021-04/graphql.json",
+               url: "https://#{Shopifex.Shops.get_url(shop)}/admin/api/2021-04/graphql.json",
                headers: [
                  "X-Shopify-Access-Token": shop.access_token,
                  "Content-Type": "application/json"
@@ -140,12 +141,13 @@ defmodule ShopifexWeb.PaymentController do
               name: plan.name,
               price: plan.price,
               test: plan.test,
-              return_url: "#{redirect_uri}?plan_id=#{plan.id}&shop=#{shop.url}"
+              return_url:
+                "#{redirect_uri}?plan_id=#{plan.id}&shop=#{Shopifex.Shops.get_url(shop)}"
             }
           })
 
         case HTTPoison.post(
-               "https://#{shop.url}/admin/api/2021-01/recurring_application_charges.json",
+               "https://#{Shopifex.Shops.get_url(shop)}/admin/api/2021-01/recurring_application_charges.json",
                body,
                "X-Shopify-Access-Token": shop.access_token,
                "Content-Type": "application/json"
@@ -164,12 +166,13 @@ defmodule ShopifexWeb.PaymentController do
               name: plan.name,
               price: plan.price,
               test: plan.test,
-              return_url: "#{redirect_uri}?plan_id=#{plan.id}&shop=#{shop.url}"
+              return_url:
+                "#{redirect_uri}?plan_id=#{plan.id}&shop=#{Shopifex.Shops.get_url(shop)}"
             }
           })
 
         case HTTPoison.post(
-               "https://#{shop.url}/admin/api/2021-01/application_charges.json",
+               "https://#{Shopifex.Shops.get_url(shop)}/admin/api/2021-01/application_charges.json",
                body,
                "X-Shopify-Access-Token": shop.access_token,
                "Content-Type": "application/json"
@@ -222,7 +225,11 @@ defmodule ShopifexWeb.PaymentController do
       @impl ShopifexWeb.PaymentController
       def after_payment(conn, shop, _plan, _grant, redirect_after) do
         api_key = Application.get_env(:shopifex, :api_key)
-        redirect(conn, external: "https://#{shop.url}/admin/apps/#{api_key}#{redirect_after}")
+
+        redirect(conn,
+          external:
+            "https://#{Shopifex.Shops.get_url(shop)}/admin/apps/#{api_key}#{redirect_after}"
+        )
       end
 
       defoverridable render_plans: 3, after_payment: 5

--- a/lib/shopifex_web/templates/page/redirect.html.eex
+++ b/lib/shopifex_web/templates/page/redirect.html.eex
@@ -2,7 +2,7 @@
     ReactPhoenix.ClientSide.react_component(
         "Components.WrappedRedirect",
         %{
-            shop_url: Shopifex.Plug.current_shop(@conn).url,
+            shop_url: Shopifex.Plug.current_shop(@conn) |> Shopifex.Shops.get_url(),
             redirect_location: @redirect_location,
             shopify_api_key: Application.get_env(:shopifex, :api_key)
         }

--- a/lib/shopifex_web/views/payment_view.ex
+++ b/lib/shopifex_web/views/payment_view.ex
@@ -12,6 +12,6 @@ defmodule ShopifexWeb.PaymentView do
   def shop_url(%Plug.Conn{} = conn) do
     conn
     |> Shopifex.Plug.current_shop()
-    |> Map.get(:url)
+    |> Shopifex.Shops.get_url()
   end
 end


### PR DESCRIPTION
For non-standard shop schemas, allow user to provide query instructions for loading shop records from the database.

Example:
```elixir
defmodule MyApp.CommercePlatformInstallation do
  use MyApp.Schema
  use Shopifex.Shop, url_field: :installation_identifier, filters: [{:platform, "shopify"}, {:disabled_at, nil}]

  schema "commerce_platform_installations" do
    field(:installation_identifier, :string)
    field(:provider, :string, default: "shopify")
    field(:disabled_at, :utc_datetime)
    # ...
  end
end
```