### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Generate the schemas
 
 `mix phx.gen.schema Shops.Plan plans name:string price:string features:array:string grants:array:string test:boolean usages:integer type:string`
 
-`mix phx.gen.schema Shops.Grant grants shop:references:shops charge_id:integer grants:array:string remaining_usages:integer total_usages:integer`
+`mix phx.gen.schema Shops.Grant grants shop_id:references:shops charge_id:integer grants:array:string remaining_usages:integer total_usages:integer`
 
 Add the config options:
 ```elixir


### PR DESCRIPTION
The name of the column was wrong. If you follow the current `README.md` you end up with:

```elixir
   1 defmodule App.Shops.Grant do
   2   use Ecto.Schema
   3   import Ecto.Changeset
   4
   5   schema "grants" do
   6     field :charge_id, :integer
   7     field :grants, {:array, :string}
   8     field :remaining_usages, :integer
   9     field :total_usages, :integer
  10     field :shop, :id # <-- HERE
  11
  12     timestamps()
  13   end
  14
  15   @doc false
  16   def changeset(grant, attrs) do
  17     grant
  18     |> cast(attrs, [:charge_id, :grants, :remaining_usages, :total_usages])
  19     |> validate_required([:charge_id, :grants, :remaining_usages, :total_usages
     ])
  20   end
  21 end
```

But the `PaymentGuard` tries to do the following:

```elixir
  70       @impl Shopifex.PaymentGuard
  71       def grant_for_guard(shop, guard) do
  72         from(s in grant_schema(),
  73           where: s.shop_id == ^shop.id, # <-- HERE
  74           where: ^guard in s.grants,
  75           where: is_nil(s.remaining_usages),
  76           or_where: s.remaining_usages > 0
  77         )
  78         |> repo().one()
  79       end
```

causing the application to failed.