### PR TITLE
Allow trailing slash on install shop form

### DIFF
--- a/lib/shopifex_web/controllers/auth_controller.ex
+++ b/lib/shopifex_web/controllers/auth_controller.ex
@@ -94,6 +94,8 @@ defmodule ShopifexWeb.AuthController do
       end
 
       def initialize_installation(conn, %{"shop" => shop_url} = params) do
+        shop_url = String.trim_trailing(shop_url, "/")
+
         if Regex.match?(~r/^.*\.myshopify\.com/, shop_url) do
           # check if store is in the system already:
           case Shopifex.Shops.get_shop_by_url(shop_url) do

--- a/test/shopifex_web/controllers/auth_controller_test.exs
+++ b/test/shopifex_web/controllers/auth_controller_test.exs
@@ -2,14 +2,22 @@ defmodule ShopifexWeb.AuthControllerTest do
   use ShopifexWeb.ConnCase, async: true
 
   test "new shop is redirected to install", %{conn: conn} do
-    conn =
-      get(conn, Routes.auth_path(@endpoint, :initialize_installation), %{
-        "shop" => "shopifex.myshopify.com"
-      })
+    # Ensure it works with and without trailing slash
+    shop_urls = [
+      "shopifex.myshopify.com",
+      "shopifex.myshopify.com/"
+    ]
 
-    assert conn.status == 302
-    [location] = Plug.Conn.get_resp_header(conn, "location")
-    assert location =~ "https://shopifex.myshopify.com/admin/oauth/authorize"
+    for shop_url <- shop_urls do
+      conn =
+        get(conn, Routes.auth_path(@endpoint, :initialize_installation), %{
+          "shop" => shop_url
+        })
+
+      assert conn.status == 302
+      [location] = Plug.Conn.get_resp_header(conn, "location")
+      assert location =~ "https://shopifex.myshopify.com/admin/oauth/authorize"
+    end
   end
 
   test "locale is an optional parameter in auth flow", %{conn: conn} do


### PR DESCRIPTION
If you (accidentally) have a trailing slash in this form, then the install does not succeed and Shopify doesn't give you any hint about what has gone wrong.

<img width="868" alt="Screenshot 2023-01-16 at 10 26 37 PM" src="https://user-images.githubusercontent.com/4924153/212796370-de4626a1-fd1e-40e2-a05f-1734c6396dd0.png">
