### PR TITLE
Fix for appSubscriptionCreate graphql query. 

### DIFF
--- a/lib/shopifex_web/controllers/payment_controller.ex
+++ b/lib/shopifex_web/controllers/payment_controller.ex
@@ -104,7 +104,7 @@ defmodule ShopifexWeb.PaymentController do
 
         case Neuron.query(
                """
-               mutation appSubscriptionCreate($name: String!, $return_url: URL!, $test: Boolean!, $price: Decimal!) {
+               mutation appSubscriptionCreate($name: String!, $return_url: URL!, $test: Boolean!, $price: Decimal!, $trial_days: Int!) {
                  appSubscriptionCreate(name: $name, returnUrl: $return_url, test: $test, trialDays: $trial_days, lineItems: [{plan: {appRecurringPricingDetails: {price: {amount: $price, currencyCode: USD}, interval: ANNUAL}}}]) {
                    appSubscription {
                      id


### PR DESCRIPTION
The appSubscriptionCreate graphql query used to create an annual subscription was failing due to using a variable called $trial_days without declaring it.

This fix adds that declaration to the query.