### PR TITLE
Fix after_update arity in override example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ defmodule MyAppWeb.AuthController do
   # Thats it! Validation, installation are now handled for you :)
   
   # Optionally, override the `after_install` callback
-  def after_install(conn, shop) do
+  def after_install(conn, shop, oauth_state) do
     # TODO: send yourself an e-mail
     # follow default behaviour.
-    super(conn, shop)
+    super(conn, shop, oauth_state)
   end
 end
 ```


### PR DESCRIPTION
This looks like it was [changed a while ago](https://github.com/ericdude4/shopifex/commit/8f34450fe390306ae7c1ac2dab1acb5783d5ca97), but the arity in the README example was not updated to reflect the change