### PR TITLE
Add support for Phoenix LiveView with shopifex_live_session macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,31 @@ EEx template form:
 <% end %>
 ```
 
+## Using LiveView in your embedded app
+There are two special considerations to using LiveView in your embedded app.
+
+First, you'll need to get the LiveView socket configured to work in the Shopify iframe. This [elixir](https://elixirforum.com/t/how-to-embed-a-liveview-via-iframe/65066) post gives some excellent tips.
+
+Second, you'll need to copy the `current_shop` and `session_token` from the Plug connection to the socket and make them available in your assigns on_mount. The `@current_shop` will be your authenticated Shop resource, and `@session_token` can be used when you navigate between live views similar to the template links above.  The `shopifex_live_session` macro is a drop-in replacement fom `live_session` to handle this.
+
+```
+scope "/", ShoplensWeb do
+  pipe_through [:shopifex_browser, :shopify_session]
+
+  ShopifexWeb.Routes.shopifex_live_session :embedded, layout: {MyApp.Layouts, :embedded} do
+    live "/", MyAppLive
+    ...
+  end
+
+  # If you need more control, you can still use `live_session` like this:
+  #  live_session :embedded, 
+  #    session: {ShopifexWeb.LiveSession, :put_shop_in_session, []}, 
+  #    on_mount: {ShopifexWeb.LiveSession, :assign_shop_to_socket} do
+  #       ...
+  #   end
+end
+```
+
 ## Update app permissions
 
 You can also update the app permissions after installation. To do so, first you have to add `your-redirect-url.com/auth/update` to Shopify's whitelist.

--- a/lib/shopifex_web/live_session.ex
+++ b/lib/shopifex_web/live_session.ex
@@ -1,0 +1,50 @@
+defmodule ShopifexWeb.LiveSession do
+  # To avoid making LiveView a dependency of the entire application, we'll
+  # silence this warning. At runtime, the LiveView module will be available
+  # if the application is using LiveView.
+  @compile {:no_warn_undefined, Phoenix.Component}
+
+  @doc """
+  Get options that should be passed to `live_session`.
+
+  This is useful for integrating with other tools that require a custom `live_session`,
+  like `beacon_live_admin`. For example:
+
+  ```elixir
+  beacon_live_admin ShopifexWeb.LiveSession.opts(...beacon_opts) do
+    ...
+  end
+  ```
+  """
+  def opts(custom_opts \\ []) do
+    on_mount = {__MODULE__, :assign_shop_to_socket}
+    session = {__MODULE__, :put_shop_in_session, []}
+
+    custom_opts
+    |> Keyword.update(:on_mount, on_mount, &([on_mount] ++ List.wrap(&1)))
+    |> Keyword.put(:session, session)
+  end
+
+  @doc """
+  Return a map of session values to include in the liveview session. This
+  will be merged with other session values and available in the on_mount.
+  """
+  def put_shop_in_session(conn) do
+    session_token = Shopifex.Plug.session_token(conn)
+    current_shop = Shopifex.Plug.current_shop(conn)
+    %{"session_token" => session_token, "current_shop" => current_shop}
+  end
+
+  @doc """
+  Add the current_shop and session_token to assigns making them available
+  in live view templates.
+  """
+  def on_mount(:assign_shop_to_socket, _params, session, socket) do
+    assigns = %{
+      current_shop: session["current_shop"],
+      session_token: session["session_token"]
+    }
+
+    {:cont, Phoenix.Component.assign(socket, assigns)}
+  end
+end

--- a/lib/shopifex_web/routes.ex
+++ b/lib/shopifex_web/routes.ex
@@ -153,4 +153,19 @@ defmodule ShopifexWeb.Routes do
       end
     end
   end
+
+  @doc """
+  Generate a live session with the current_shop and session token assigned. All other
+  options are passed through to `live_session`.
+  """
+  @spec shopifex_live_session(atom, opts :: Keyword.t()) :: Macro.t()
+  defmacro shopifex_live_session(session_name, opts \\ [], do: block) do
+    quote do
+      shopifex_live_session_opts = unquote(opts) |> ShopifexWeb.LiveSession.opts()
+
+      Phoenix.LiveView.Router.live_session unquote(session_name), shopifex_live_session_opts do
+        unquote(block)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a shopifex_live_session macro and a support Shopifex.LiveSession module that makes it relatively easy to use Shopifex with Phoenix LiveView