### PR TITLE
fix: customer/redact boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ defmodule MyAppWeb.WebhookController do
 
   # Mandatory Shopify customer data erasure GDPR webhook. Simply delete the shop (customer) record
   def handle_topic(conn, shop, "customers/redact") do
-    Shopifex.Shops.delete_shop(shop)
+    # If you store customer data you can delete it here.
 
     conn
     |> send_resp(204, "")

--- a/lib/mix/shopifex/controller.ex
+++ b/lib/mix/shopifex/controller.ex
@@ -35,7 +35,7 @@ defmodule Mix.Shopifex.Controller do
 
     # Mandatory Shopify customer data erasure GDPR webhook. Simply delete the shop (customer) record
     def handle_topic(conn, shop, "customers/redact") do
-      Shopifex.Shops.delete_shop(shop)
+      # If you store customer data you can delete it here.
 
       conn
       |> send_resp(204, "")


### PR DESCRIPTION
Fixes a bug in the webhooks controller boilerplate where we could potentially delete a shop record when a GDPR compliance request comes in.

Edit:
There might have been some confusing as to what customer refers to see https://shopify.dev/docs/apps/build/privacy-law-compliance#customers-redact