### PR TITLE
Allow POSTs with signature to be verified

### DIFF
--- a/lib/shopifex/plug.ex
+++ b/lib/shopifex/plug.ex
@@ -91,16 +91,42 @@ defmodule Shopifex.Plug do
   end
 
   @spec build_hmac(conn :: Plug.Conn.t()) :: String.t()
-  def build_hmac(%Plug.Conn{method: "GET"} = conn) do
-    # hmac param takes precedence and is present in App load requests.
-    # signature param is present in Shopify App proxy requests https://shopify.dev/apps/online-store/app-proxies
-    {signature_param, query_string_joiner} =
-      if Map.has_key?(conn.query_params, "hmac"), do: {"hmac", "&"}, else: {"signature", ""}
+  def build_hmac(%Plug.Conn{} = conn) do
+    query_params = conn.query_params
 
+    cond do
+      Map.has_key?(query_params, "hmac") ->
+        # hmac param takes precedence and is present in App load requests.
+        query_string_hmac(query_params, "&")
+
+      Map.has_key?(conn.query_params, "signature") ->
+        # signature param is present in Shopify App proxy requests https://shopify.dev/apps/online-store/app-proxies
+        query_params
+        |> Map.delete("signature")
+        |> query_string_hmac()
+
+      conn.method == "POST" ->
+        post_body_hmac(conn)
+    end
+  end
+
+  @spec get_hmac(conn :: Plug.Conn.t()) :: String.t() | nil
+  def get_hmac(%Plug.Conn{params: %{"hmac" => hmac}}), do: String.downcase(hmac)
+
+  def get_hmac(%Plug.Conn{params: %{"signature" => signature}}), do: String.downcase(signature)
+
+  def get_hmac(%Plug.Conn{} = conn) do
+    with [hmac_header] <- Plug.Conn.get_req_header(conn, "x-shopify-hmac-sha256") do
+      String.downcase(hmac_header)
+    else
+      _ -> nil
+    end
+  end
+
+  defp query_string_hmac(params, joiner \\ "") do
     query_string =
-      conn.query_params
-      |> Map.delete(signature_param)
-      |> Enum.map_join(query_string_joiner, fn
+      params
+      |> Enum.map_join(joiner, fn
         {"ids", value} ->
           # This absolutely rediculous solution: https://community.shopify.com/c/Shopify-Apps/Hmac-Verification-for-Bulk-Actions/m-p/590611#M18504
           ids =
@@ -125,7 +151,7 @@ defmodule Shopifex.Plug do
     |> String.downcase()
   end
 
-  def build_hmac(%Plug.Conn{method: "POST"} = conn) do
+  defp post_body_hmac(%Plug.Conn{method: "POST"} = conn) do
     :crypto.mac(
       :hmac,
       :sha256,
@@ -134,18 +160,5 @@ defmodule Shopifex.Plug do
     )
     |> Base.encode64()
     |> String.downcase()
-  end
-
-  @spec get_hmac(conn :: Plug.Conn.t()) :: String.t() | nil
-  def get_hmac(%Plug.Conn{params: %{"hmac" => hmac}}), do: String.downcase(hmac)
-
-  def get_hmac(%Plug.Conn{params: %{"signature" => signature}}), do: String.downcase(signature)
-
-  def get_hmac(%Plug.Conn{} = conn) do
-    with [hmac_header] <- Plug.Conn.get_req_header(conn, "x-shopify-hmac-sha256") do
-      String.downcase(hmac_header)
-    else
-      _ -> nil
-    end
   end
 end


### PR DESCRIPTION
Posting through an app proxy will result in a POST with signed query params that need to be verified.

This refactor allows more than GETs to be verified, while leaving the existing paths untouched:

* POSTs without signature will continue to be verified via their raw_body
* GETs with "hmac" params will be treated the same as before