### PR TITLE
Allow POSTs with signature to be verified

### DIFF
--- a/lib/shopifex/plug.ex
+++ b/lib/shopifex/plug.ex
@@ -91,38 +91,23 @@ defmodule Shopifex.Plug do
   end
 
   @spec build_hmac(conn :: Plug.Conn.t()) :: String.t()
-  def build_hmac(%Plug.Conn{method: "GET"} = conn) do
+  def build_hmac(%Plug.Conn{query_params: %{"hmac" => _}} = conn) do
     # hmac param takes precedence and is present in App load requests.
+    conn.query_params
+    |> Map.delete("hmac")
+    |> query_string_hmac("&")
+  end
+
+  def build_hmac(%Plug.Conn{query_params: %{"signature" => _}} = conn) do
     # signature param is present in Shopify App proxy requests https://shopify.dev/apps/online-store/app-proxies
-    {signature_param, query_string_joiner} =
-      if Map.has_key?(conn.query_params, "hmac"), do: {"hmac", "&"}, else: {"signature", ""}
+    conn.query_params
+    |> Map.delete("signature")
+    |> query_string_hmac()
+  end
 
-    query_string =
-      conn.query_params
-      |> Map.delete(signature_param)
-      |> Enum.map_join(query_string_joiner, fn
-        {"ids", value} ->
-          # This absolutely rediculous solution: https://community.shopify.com/c/Shopify-Apps/Hmac-Verification-for-Bulk-Actions/m-p/590611#M18504
-          ids =
-            Enum.map(value, fn id ->
-              "\"#{id}\""
-            end)
-            |> Enum.join(", ")
-
-          "ids=[#{ids}]"
-
-        {key, value} ->
-          "#{key}=#{value}"
-      end)
-
-    :crypto.mac(
-      :hmac,
-      :sha256,
-      Application.fetch_env!(:shopifex, :secret),
-      query_string
-    )
-    |> Base.encode16()
-    |> String.downcase()
+  def build_hmac(%Plug.Conn{method: "GET"} = conn) do
+    conn.query_params
+    |> query_string_hmac()
   end
 
   def build_hmac(%Plug.Conn{method: "POST"} = conn) do
@@ -147,5 +132,32 @@ defmodule Shopifex.Plug do
     else
       _ -> nil
     end
+  end
+
+  defp query_string_hmac(query_params, joiner \\ "") do
+    query_string =
+      query_params
+      |> Enum.map_join(joiner, fn
+        {"ids", value} ->
+          # This absolutely ridiculous solution: https://community.shopify.com/c/Shopify-Apps/Hmac-Verification-for-Bulk-Actions/m-p/590611#M18504
+          ids =
+            Enum.map(value, fn id ->
+              "\"#{id}\""
+            end)
+            |> Enum.join(", ")
+
+          "ids=[#{ids}]"
+
+        {key, value} ->
+          "#{key}=#{value}"
+      end)
+
+    :crypto.mac(
+      :hmac,
+      :sha256,
+      Application.fetch_env!(:shopifex, :secret),
+      query_string
+    )
+    |> Base.encode16(case: :lower)
   end
 end

--- a/test/shopifex/plug_test.exs
+++ b/test/shopifex/plug_test.exs
@@ -52,6 +52,21 @@ defmodule Shopifex.PlugTest do
                |> Plug.Conn.assign(:raw_body, "{\"foo\": \"bar\"}")
                |> Shopifex.Plug.build_hmac()
     end
+
+    test "POST with signature query param" do
+      assert "3cf1f3876199f1b4254ff0f6a2d1e867e8ea5c0555ccff923c74547ae4da414b" =
+               Shopifex.Plug.build_hmac(%Plug.Conn{
+                 method: "POST",
+                 query_params: %{
+                   "logged_in_customer_id" => "",
+                   "path_prefix" => "/apps/fw-cart-redirect-page",
+                   "shop" => "shopifex.myshopify.com",
+                   "signature" =>
+                     "5056c56d0cfa96fc37683faa5653af2ff5412ea4dd5233db139367010999f6b5",
+                   "timestamp" => "1667857512"
+                 }
+               })
+    end
   end
 
   describe "get_hmac/1" do


### PR DESCRIPTION
Posting through an app proxy will result in a POST with signed query params that need to be verified.

This refactor allows more than GETs to be verified, while leaving the existing paths untouched:

* POSTs without signature will continue to be verified via their raw_body
* GETs with "hmac" params will be treated the same as before